### PR TITLE
Allow for large field configs in filters

### DIFF
--- a/resources/js/components/fieldtypes/Mixins/UsesFields.vue
+++ b/resources/js/components/fieldtypes/Mixins/UsesFields.vue
@@ -71,7 +71,7 @@ export default {
                  })),
             };
 
-            this.$axios.get(cp_url('fields/field-meta'), { params }).then(response => {
+            this.$axios.post(cp_url('fields/field-meta'), params).then(response => {
                 this.updateMeta(response.data.meta);
             });
         },


### PR DESCRIPTION
This pull request replicates the fix from statamic/cms#10822 into this addon. We may remove the `GET` version of this endpoint in future major versions (update: it's being removed in Statamic 6, see statamic/cms#11345).

I haven't pulled down this addon locally to test with, so it might be worth double checking everything still works before merging.